### PR TITLE
Resolve build warning, since Flutter 3.0

### DIFF
--- a/lib/src/animation_limiter.dart
+++ b/lib/src/animation_limiter.dart
@@ -40,7 +40,7 @@ class _AnimationLimiterState extends State<AnimationLimiter> {
   void initState() {
     super.initState();
 
-    WidgetsBinding.instance!.addPostFrameCallback((Duration value) {
+    WidgetsBinding.instance.addPostFrameCallback((Duration value) {
       if (!mounted) return;
       setState(() {
         _shouldRunAnimation = false;


### PR DESCRIPTION
# Problem
Since the release of Flutter 3.0 there is a warning during the build of an app, using this package.

## The Warning:
```
: Warning: Operand of null-aware operation '!' has type 'WidgetsBinding' which excludes null.
../…/src/animation_limiter.dart:43
- 'WidgetsBinding' is from 'package:flutter/src/widgets/binding.dart' ('../../../fvm/versions/stable/packages/flutter/lib/src/widgets/binding.dart').
package:flutter/…/widgets/binding.dart:1
    WidgetsBinding.instance!.addPostFrameCallback((Duration value) {
```

# Fix:
I removed "!" from the instance property, because since the Flutter 3.0 release the instance getter will not return null anymore. As you can see here: [binding.dart#L304](https://github.com/flutter/flutter/blob/ab89ce285f76a3fd3a9328ec863f5623cc5ac8bc/packages/flutter/lib/src/widgets/binding.dart#L304)
The commit associated with this change is this one: [ab89ce285f76a3fd3a9328ec863f5623cc5ac8bc](https://github.com/flutter/flutter/commit/ab89ce285f76a3fd3a9328ec863f5623cc5ac8bc)


## Information
This merge would eliminate the support for all Flutter versions < 3.0.
